### PR TITLE
Add investing approach and refresh identity

### DIFF
--- a/_includes/components/intro.md
+++ b/_includes/components/intro.md
@@ -1,4 +1,4 @@
-### Entrepreneur, engineer, gamer, biohacker, digital nomad.
+### Engineer, entrepreneur, gamer, biohacker.
 
 Currently:   
 - <a href="/about.html#colonist">Founder @ Colonist.io: A web alternative to the top selling board game Settlers of Catan</a>  

--- a/_includes/components/intro.md
+++ b/_includes/components/intro.md
@@ -1,4 +1,4 @@
-### Engineer, entrepreneur, investor, gamer. 
+### Entrepreneur, engineer, gamer, biohacker, digital nomad.
 
 Currently:   
 - <a href="/about.html#colonist">Founder @ Colonist.io: A web alternative to the top selling board game Settlers of Catan</a>  

--- a/_includes/structure/head.html
+++ b/_includes/structure/head.html
@@ -2,7 +2,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Personal webpage of Goktug Yilmaz. An Engineer, entrepreneur, investor, gamer.">
+    <meta name="description" content="Personal webpage of Goktug Yilmaz. Entrepreneur, engineer, gamer, biohacker, digital nomad.">
     <meta name="keywords" content="gamer,esqarrouth,software,engineer,swift,typescript,io,games,entrepreneur,startup,dawn,of,crafting">
     <meta name="author" content="Goktug Yilmaz">
 
@@ -23,4 +23,3 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/theme/css/syntax.css">
 
 </head>
-

--- a/_includes/structure/head.html
+++ b/_includes/structure/head.html
@@ -2,7 +2,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Personal webpage of Goktug Yilmaz. Entrepreneur, engineer, gamer, biohacker, digital nomad.">
+    <meta name="description" content="Personal webpage of Goktug Yilmaz. Engineer, entrepreneur, gamer, biohacker.">
     <meta name="keywords" content="gamer,esqarrouth,software,engineer,swift,typescript,io,games,entrepreneur,startup,dawn,of,crafting">
     <meta name="author" content="Goktug Yilmaz">
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,7 +4,7 @@ permalink: about.html
 narrow: true
 ---
 
-### Engineer, entrepreneur, investor, gamer. 
+### Entrepreneur, engineer, gamer, biohacker, digital nomad.
 
 Currently:   
 - <a href="#colonist">Founder of Colonist.io: A web alternative to the top selling board game Settlers of Catan</a>  
@@ -81,6 +81,16 @@ We’ve worked on various projects in the cryptocurrency space. These include:
 #### <a id="barakatech" href="https://www.barakatech.com/">**Barakatech**</a>
 - Company founded by <a href="http://www.nokta.com">Nokta Media</a> founders (Turkey's biggest social media conglomerate)
 - I advised the team about blockchain technologies from product, engineering and business perspectives
+
+<hr />
+
+## Investing
+
+- I primarily invest through early-stage-focused fund managers and angels.
+- I invest directly in companies only when I feel unusually close to the product, people, mission, or problem.
+- I don’t treat investment returns as a personal achievement. What interests me is learning how founders, technology, markets, and incentives interact; participating in a company’s journey in a small way; and putting capital to productive work rather than simply chasing gains.
+- Earlier, I spent years with a crypto-only portfolio and also experimented with broad direct startup investing.
+- My current conclusion is that I would rather identify exceptional people who consistently find and support great founders than try to personally pick every winning company. I believe I have better odds evaluating the evaluators.
 
 <hr />
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,7 +4,7 @@ permalink: about.html
 narrow: true
 ---
 
-### Entrepreneur, engineer, gamer, biohacker, digital nomad.
+### Engineer, entrepreneur, gamer, biohacker.
 
 Currently:   
 - <a href="#colonist">Founder of Colonist.io: A web alternative to the top selling board game Settlers of Catan</a>  


### PR DESCRIPTION
## Summary
- add a concise Investing section focused on strategy and philosophy
- refresh the short public identity to entrepreneur, engineer, gamer, biohacker, and digital nomad
- update the site metadata to match

## Verification
- bundle exec jekyll build --destination /private/tmp/goktugyil-investing-site